### PR TITLE
Align release flow and npm scripts with wework-cli reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,19 +30,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Publish npm package
-        working-directory: npm
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          npm version --no-git-tag-version "$VERSION"
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,8 +19,9 @@ builds:
     goarm:
       - 7
     ignore:
-      # Windows ARMv7 isn't a thing we want to ship.
       - goos: windows
+        goarch: arm
+      - goos: darwin
         goarch: arm
     flags:
       - -trimpath

--- a/mise.development.toml
+++ b/mise.development.toml
@@ -1,0 +1,14 @@
+[tools]
+goreleaser = "latest"
+
+[tasks.goreleaser_snapshot]
+description = "Build CLI artifacts via GoReleaser (snapshot)"
+run = "goreleaser release --snapshot --clean --config .goreleaser.yml"
+
+[tasks.goreleaser_release]
+description = "Publish GitHub Release via GoReleaser"
+run = "goreleaser release --clean --config .goreleaser.yml"
+
+[tasks.release]
+description = "Alias for goreleaser_release"
+run = "mise run goreleaser_release"

--- a/mise.development.toml
+++ b/mise.development.toml
@@ -11,4 +11,4 @@ run = "goreleaser release --clean --config .goreleaser.yml"
 
 [tasks.release]
 description = "Alias for goreleaser_release"
-run = "mise run goreleaser_release"
+depends = ["goreleaser_release"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,6 @@
 [tools]
 go = "1.25.7"
 node = "20"
-goreleaser = "latest"
 
 [tasks.build]
 run = "go build -o ./codex-proxy ./cmd/codex-proxy"
@@ -10,18 +9,6 @@ description = "Build the codex-proxy binary"
 [tasks.test]
 run = "go test ./..."
 description = "Run Go tests"
-
-[tasks.release]
-run = "mise run goreleaser_release"
-description = "Alias for goreleaser_release"
-
-[tasks.goreleaser_snapshot]
-description = "Build CLI artifacts via GoReleaser (snapshot)"
-run = "goreleaser release --snapshot --clean --config .goreleaser.yml"
-
-[tasks.goreleaser_release]
-description = "Publish GitHub Release via GoReleaser"
-run = "goreleaser release --clean --config .goreleaser.yml"
 
 [tasks.publish]
 run = "cd npm/ && npm publish"

--- a/npm/index.js
+++ b/npm/index.js
@@ -54,7 +54,8 @@ async function main() {
   });
   child.on("error", (err) => {
     console.error(err.message);
-    process.exitCode = 1;
+    try { updateAbort.abort(); } catch {}
+    process.exit(1);
   });
 }
 

--- a/npm/index.js
+++ b/npm/index.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const { spawn } = require("child_process");
 
+const { installBinary } = require("./postinstall");
 const { startUpdateCheck } = require("./update_check");
 
 const exe = process.platform === "win32" ? "codex-proxy.exe" : "codex-proxy";
@@ -16,35 +17,48 @@ const PKG = (() => {
   }
 })();
 
-if (!fs.existsSync(binPath)) {
-  console.error(`Binary not found: ${binPath}`);
+async function main() {
+  if (!fs.existsSync(binPath)) {
+    await installBinary();
+  }
+
+  if (!fs.existsSync(binPath)) {
+    console.error(`Binary not found: ${binPath}`);
+    process.exit(1);
+  }
+
+  if (process.platform !== "win32") {
+    try {
+      fs.chmodSync(binPath, 0o755);
+    } catch {}
+  }
+
+  const child = spawn(binPath, process.argv.slice(2), {
+    stdio: "inherit",
+    windowsHide: true,
+  });
+
+  // Best-effort update notice (cached + short timeout).
+  // Aborts on command exit so it never delays shutdown.
+  const updateAbort = new AbortController();
+  startUpdateCheck({
+    installedVersion: PKG && PKG.version,
+    signal: updateAbort.signal,
+  });
+
+  child.on("exit", (code) => {
+    try {
+      updateAbort.abort();
+    } catch {}
+    process.exitCode = code == null ? 1 : code;
+  });
+  child.on("error", (err) => {
+    console.error(err.message);
+    process.exitCode = 1;
+  });
+}
+
+main().catch((err) => {
+  console.error(`codex-proxy: failed to install binary: ${err.message}`);
   process.exit(1);
-}
-
-if (process.platform !== "win32") {
-  try {
-    fs.chmodSync(binPath, 0o755);
-  } catch {}
-}
-
-const child = spawn(binPath, process.argv.slice(2), {
-  stdio: "inherit",
-  windowsHide: true,
 });
-
-// Best-effort update notice (cached + short timeout).
-// Aborts on command exit so it never delays shutdown.
-const updateAbort = new AbortController();
-startUpdateCheck({ installedVersion: PKG && PKG.version, signal: updateAbort.signal });
-
-child.on("exit", (code) => {
-  try {
-    updateAbort.abort();
-  } catch {}
-  process.exitCode = code == null ? 1 : code;
-});
-child.on("error", (err) => {
-  console.error(err.message);
-  process.exitCode = 1;
-});
-

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -17,7 +17,12 @@ const PLATFORM_ENV = "CODEX_PROXY_PLATFORM";
 function httpGet(url, { headers } = {}) {
   return new Promise((resolve, reject) => {
     const req = https.get(url, { headers }, (res) => {
-      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+      if (
+        res.statusCode &&
+        res.statusCode >= 300 &&
+        res.statusCode < 400 &&
+        res.headers.location
+      ) {
         resolve(httpGet(res.headers.location, { headers }));
         return;
       }
@@ -65,107 +70,113 @@ function parseChecksums(text) {
   return map;
 }
 
-(async function main() {
-  try {
-    const platformRaw = process.env[PLATFORM_ENV] || process.platform;
-    const platform = platformRaw === "win32" ? "windows" : platformRaw;
-    if (!["darwin", "linux", "windows"].includes(platform)) {
-      console.error("codex-proxy: npm install supports macOS (darwin), Linux, and Windows only");
-      process.exit(1);
-    }
+async function installBinary() {
+  const platformRaw = process.env[PLATFORM_ENV] || process.platform;
+  const platform = platformRaw === "win32" ? "windows" : platformRaw;
+  if (!["darwin", "linux", "windows"].includes(platform)) {
+    throw new Error(
+      "codex-proxy: npm install supports macOS (darwin), Linux, and Windows only",
+    );
+  }
 
-    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "package.json"), "utf8"));
-    const version = process.env[VERSION_ENV] || pkg.version || "";
-    if (!version) {
-      console.error("postinstall: could not determine version");
-      process.exit(1);
-    }
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "package.json"), "utf8"),
+  );
+  const version = process.env[VERSION_ENV] || pkg.version || "";
+  if (!version) {
+    throw new Error("postinstall: could not determine version");
+  }
 
-    const detectedArch =
-      process.arch === "x64"
-        ? "amd64"
-        : process.arch === "arm64"
-          ? "arm64"
-          : process.arch === "arm"
-            ? "armv7"
-            : process.arch;
-    const arch = process.env[ARCH_ENV] || detectedArch;
-    if (!["amd64", "arm64", "armv7"].includes(arch)) {
-      console.error(`Unsupported arch: ${arch}`);
-      process.exit(1);
-    }
-    if (platform === "windows" && arch === "armv7") {
-      console.error(`Unsupported Windows arch: ${arch}`);
-      process.exit(1);
-    }
+  const detectedArch =
+    process.arch === "x64"
+      ? "amd64"
+      : process.arch === "arm64"
+        ? "arm64"
+        : process.arch === "arm"
+          ? "armv7"
+          : process.arch;
+  const arch = process.env[ARCH_ENV] || detectedArch;
+  if (!["amd64", "arm64", "armv7"].includes(arch)) {
+    throw new Error(`Unsupported arch: ${arch}`);
+  }
+  if (platform === "windows" && arch === "armv7") {
+    throw new Error(`Unsupported Windows arch: ${arch}`);
+  }
 
-    const assetName = `${BIN}_${version}_${platform}_${arch}.tar.gz`;
-    const baseOverride = process.env[BASE_URL_ENV];
-    const bases = baseOverride
-      ? [baseOverride]
-      : [
-          `https://github.com/${OWNER}/${REPO}/releases/download/${version}`,
-          `https://github.com/${OWNER}/${REPO}/releases/download/v${version}`,
-        ];
-    const headers = { "User-Agent": `${REPO}-postinstall` };
-    const outDir = __dirname;
-    const exe = platform === "windows" ? `${BIN}.exe` : BIN;
-    const binPath = path.join(outDir, exe);
+  const assetName = `${BIN}_${version}_${platform}_${arch}.tar.gz`;
+  const baseOverride = process.env[BASE_URL_ENV];
+  const bases = baseOverride
+    ? [baseOverride]
+    : [
+        `https://github.com/${OWNER}/${REPO}/releases/download/${version}`,
+        `https://github.com/${OWNER}/${REPO}/releases/download/v${version}`,
+      ];
+  const headers = { "User-Agent": `${REPO}-postinstall` };
+  const outDir = __dirname;
+  const exe = platform === "windows" ? `${BIN}.exe` : BIN;
+  const binPath = path.join(outDir, exe);
 
-    if (fs.existsSync(binPath)) {
-      try {
-        fs.chmodSync(binPath, 0o755);
-      } catch {}
-      return;
-    }
-
-    let tarGz = null;
-    let baseUsed = "";
-    let lastErr = null;
-    for (const base of bases) {
-      const url = `${base}/${assetName}`;
-      console.log(`postinstall: downloading ${assetName} from ${url}`);
-      try {
-        tarGz = await httpGet(url, { headers });
-        baseUsed = base;
-        break;
-      } catch (e) {
-        lastErr = e;
-      }
-    }
-    if (!tarGz) throw lastErr || new Error("failed to download binary");
-
-    // checksum (best effort)
-    try {
-      const checksumsUrl = `${baseUsed}/checksums.txt`;
-      const checksumsBuf = await httpGet(checksumsUrl, { headers });
-      const checksums = parseChecksums(checksumsBuf.toString("utf8"));
-      const sumExpected = checksums.get(assetName);
-      if (!sumExpected) throw new Error("asset not in checksums.txt");
-      const sumActual = sha256(tarGz);
-      if (sumActual.toLowerCase() !== sumExpected.toLowerCase()) throw new Error("checksum mismatch");
-      console.log("postinstall: checksum OK");
-    } catch (e) {
-      console.warn(`postinstall: checksum skipped/failed: ${e.message}`);
-    }
-
-    // extract only the binary into npm directory (archive contains binary at root)
-    const tmpFile = path.join(os.tmpdir(), `${REPO}-${Date.now()}.tar.gz`);
-    fs.writeFileSync(tmpFile, tarGz);
-    const tarRes = spawnSync("tar", ["-xzf", tmpFile, "-C", outDir, exe], { stdio: "inherit" });
-    if (tarRes.status !== 0) {
-      console.error("postinstall: failed to extract binary");
-      process.exit(1);
-    }
+  if (fs.existsSync(binPath)) {
     try {
       fs.chmodSync(binPath, 0o755);
     } catch {}
+    return;
+  }
+
+  let tarGz = null;
+  let baseUsed = "";
+  let lastErr = null;
+  for (const base of bases) {
+    const url = `${base}/${assetName}`;
+    console.log(`postinstall: downloading ${assetName} from ${url}`);
     try {
-      fs.unlinkSync(tmpFile);
-    } catch {}
-    console.log(`postinstall: installed ${exe} to ${outDir}`);
-  } catch (err) {
+      tarGz = await httpGet(url, { headers });
+      baseUsed = base;
+      break;
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  if (!tarGz) throw lastErr || new Error("failed to download binary");
+
+  // checksum (best effort)
+  try {
+    const checksumsUrl = `${baseUsed}/checksums.txt`;
+    const checksumsBuf = await httpGet(checksumsUrl, { headers });
+    const checksums = parseChecksums(checksumsBuf.toString("utf8"));
+    const sumExpected = checksums.get(assetName);
+    if (!sumExpected) throw new Error("asset not in checksums.txt");
+    const sumActual = sha256(tarGz);
+    if (sumActual.toLowerCase() !== sumExpected.toLowerCase())
+      throw new Error("checksum mismatch");
+    console.log("postinstall: checksum OK");
+  } catch (e) {
+    console.warn(`postinstall: checksum skipped/failed: ${e.message}`);
+  }
+
+  // extract only the binary into npm directory (archive contains binary at root)
+  const tmpFile = path.join(os.tmpdir(), `${REPO}-${Date.now()}.tar.gz`);
+  fs.writeFileSync(tmpFile, tarGz);
+  const tarRes = spawnSync("tar", ["-xzf", tmpFile, "-C", outDir, exe], {
+    stdio: "inherit",
+  });
+  if (tarRes.status !== 0) {
+    throw new Error("postinstall: failed to extract binary");
+  }
+  try {
+    fs.chmodSync(binPath, 0o755);
+  } catch {}
+  try {
+    fs.unlinkSync(tmpFile);
+  } catch {}
+  console.log(`postinstall: installed ${exe} to ${outDir}`);
+}
+
+if (require.main === module) {
+  installBinary().catch((err) => {
     console.error(`postinstall error: ${err.message}`);
     process.exit(1);
-  }
-})();
+  });
+}
+
+module.exports = { installBinary };

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -157,18 +157,20 @@ async function installBinary() {
   // extract only the binary into npm directory (archive contains binary at root)
   const tmpFile = path.join(os.tmpdir(), `${REPO}-${Date.now()}.tar.gz`);
   fs.writeFileSync(tmpFile, tarGz);
-  const tarRes = spawnSync("tar", ["-xzf", tmpFile, "-C", outDir, exe], {
-    stdio: "inherit",
-  });
-  if (tarRes.status !== 0) {
-    throw new Error("postinstall: failed to extract binary");
+  try {
+    const tarRes = spawnSync("tar", ["-xzf", tmpFile, "-C", outDir, exe], {
+      stdio: "inherit",
+    });
+    if (tarRes.status !== 0) {
+      try { fs.unlinkSync(binPath); } catch {}
+      throw new Error("postinstall: failed to extract binary");
+    }
+    try {
+      fs.chmodSync(binPath, 0o755);
+    } catch {}
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch {}
   }
-  try {
-    fs.chmodSync(binPath, 0o755);
-  } catch {}
-  try {
-    fs.unlinkSync(tmpFile);
-  } catch {}
   console.log(`postinstall: installed ${exe} to ${outDir}`);
 }
 


### PR DESCRIPTION
## Summary

- Remove npm publish steps from `release.yml` — publish is now manual only, matching wework-cli
- Refactor `postinstall.js` from IIFE pattern to exported `installBinary` function
- Make `index.js` async with auto-install fallback (calls `installBinary()` if binary missing at runtime)