### PR TITLE
Align npm/release flow with wework-cli

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,5 @@
 [tools]
 go = "1.25.7"
-node = "20"
 
 [tasks.build]
 run = "go build -o ./codex-proxy ./cmd/codex-proxy"


### PR DESCRIPTION
Aligns the npm wrapper and release flow to match wework-cli.

## Changes
- Add `npm/` package with `postinstall.js`, `index.js`, `update_check.js` following the same binary-download pattern as wework-cli
- Add `.goreleaser.yml` for multi-platform binary builds (triggered on tags only)
- Add `.github/workflows/release.yml` — runs GoReleaser on tag push, no npm publish step
- Move goreleaser tasks to `mise.development.toml` (only loaded with `MISE_ENV=development`)
- Remove `node` from `mise.toml` managed tools