### PR TITLE
Add DISABLE_HEALTH_LOGS option to silence /health request logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ export ACCOUNT_ID="your-account-id"
 ```bash
 export PORT="3000"  # default: 9879
 export ENV="production"  # default: development (console logs)
+export DISABLE_HEALTH_LOGS="true"  # default: false; disables request logging for /health
 ```
 
 **Migration logs**:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,10 +9,12 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/dvcrn/codex-oauth-proxy/internal/credentials"
+	"github.com/dvcrn/codex-oauth-proxy/internal/env"
 	"github.com/rs/zerolog"
 )
 
@@ -36,18 +38,22 @@ type HTTPClient interface {
 }
 
 type Server struct {
-	credsFetcher credentials.CredentialsFetcher
-	httpClient   HTTPClient
-	mux          *http.ServeMux
-	logger       zerolog.Logger
+	credsFetcher      credentials.CredentialsFetcher
+	httpClient        HTTPClient
+	mux               *http.ServeMux
+	logger            zerolog.Logger
+	disableHealthLogs bool
 }
 
 func New(logger zerolog.Logger, credsFetcher credentials.CredentialsFetcher) *Server {
+	disableHealthLogs, _ := strconv.ParseBool(env.GetOrDefault("DISABLE_HEALTH_LOGS", "false"))
+
 	s := &Server{
-		credsFetcher: credsFetcher,
-		httpClient:   NewHTTPClient(),
-		mux:          http.NewServeMux(),
-		logger:       logger,
+		credsFetcher:      credsFetcher,
+		httpClient:        NewHTTPClient(),
+		mux:               http.NewServeMux(),
+		logger:            logger,
+		disableHealthLogs: disableHealthLogs,
 	}
 
 	s.setupRoutes()
@@ -70,6 +76,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.disableHealthLogs && r.URL.Path == "/health" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		start := time.Now()
 		s.logger.Info().
 			Str("method", r.Method).


### PR DESCRIPTION
Health-check probes generate noisy request logs. Setting DISABLE_HEALTH_LOGS=true skips the logging middleware for /health requests. Defaults to false, preserving current behavior.