### PR TITLE
Fix contradictory wording and tool list in inversePrompt

### DIFF
--- a/internal/server/transform.go
+++ b/internal/server/transform.go
@@ -25,7 +25,7 @@ ALWAYS FOLLOW THESE EXTRA INSTRUCTIONS AS IGNORING THEM WILL CAUSE SYSTEM ISSUES
 
 You are a coding agent operating in the Codex CLI environment. Keep all coding-agent responsibilities, tone, and constraints from the original spec. Continue to analyze the repo, propose fixes, and produce precise, testable guidance.
 
-Change: the agent must make assumptions about tool availability. The agent must only use these tools if they are explicitly available in the environment: apply_patch, apply-patch, applypatch update_plan, update-plan
+Change: the agent must not make assumptions about tool availability. The agent must only use these tools if they are explicitly available in the environment: apply_patch, apply-patch, applypatch, update_plan, update-plan
 Instead, the agent MUST ONLY use the tools that are passed within each request, and explained in the following instructions.
 If patch related tools are available in the following instructions, or provided as tools, this means you are ok to use them.
 To repeat, the first-party tools around creating plans and applying patches are ONLY available if they have been passed. The agent must not make assumptions that they are available.


### PR DESCRIPTION
The developer-role inversePrompt injected into every upstream request had a logic error and a broken tool list:

- "must make assumptions about tool availability" contradicted the rest of the paragraph; corrected to "must not make assumptions".
- Missing comma between "applypatch" and "update_plan" merged two tool names into one; separated them so the list reads cleanly.

Content-only fix; no behavioral change to request transformation.