### PR TITLE
feat: support GPT-5.6 Sol and bump upstream Codex version

### DIFF
--- a/internal/server/models.go
+++ b/internal/server/models.go
@@ -12,6 +12,7 @@ const (
 	modelGPT53Codex      = "gpt-5.3-codex"
 	modelGPT53CodexSpark = "gpt-5.3-codex-spark"
 	modelGPT55           = "gpt-5.5"
+	modelGPT5Sol         = "gpt-5.6-sol"
 
 	modelGPT5CodexMini  = "gpt-5-codex-mini"
 	modelGPT51CodexMini = "gpt-5.1-codex-mini"
@@ -28,6 +29,7 @@ var modelAllowedEfforts = map[string][]string{
 	modelGPT53Codex:      {"low", "medium", "high", "xhigh"},
 	modelGPT53CodexSpark: {"low", "medium", "high", "xhigh"},
 	modelGPT55:           {"low", "medium", "high", "xhigh"},
+	modelGPT5Sol:         {"low", "medium", "high", "xhigh"},
 	modelGPT5Codex:       {"minimal", "low", "medium", "high"},
 	modelGPT51:           {"low", "medium", "high"},
 	modelGPT51Codex:      {"low", "medium", "high"},
@@ -46,6 +48,7 @@ var modelDefaultEffort = map[string]string{
 	modelGPT53Codex:      "medium",
 	modelGPT53CodexSpark: "high",
 	modelGPT55:           "medium",
+	modelGPT5Sol:         "medium",
 	modelGPT51Codex:      "low",
 	modelGPT51CodexMax:   "low",
 	modelGPT5CodexMini:   "medium",
@@ -301,6 +304,38 @@ var modelMetadataByID = map[string]modelMetadata{
 		Vendor:  "OpenAI",
 		Version: "gpt-5.5",
 	},
+	modelGPT5Sol: {
+		Capabilities: map[string]interface{}{
+			"family": "gpt-5.6-sol",
+			"limits": map[string]interface{}{
+				"max_context_window_tokens": 1050000,
+				"max_output_tokens":         128000,
+				"max_prompt_tokens":         922000,
+				"vision": map[string]interface{}{
+					"max_prompt_image_size": 3145728,
+					"max_prompt_images":     1,
+					"supported_media_types": []string{"image/jpeg", "image/png", "image/webp", "image/gif"},
+				},
+			},
+			"object":    "model_capabilities",
+			"supports":  map[string]interface{}{"parallel_tool_calls": true, "streaming": true, "structured_outputs": true, "tool_calls": true, "vision": true},
+			"tokenizer": "o200k_base",
+			"type":      "chat",
+		},
+		ID:                  modelGPT5Sol,
+		ModelPickerCategory: "powerful",
+		ModelPickerEnabled:  true,
+		Name:                "GPT-5.6 Sol",
+		Object:              "model",
+		Policy: &modelPolicy{
+			State: "enabled",
+			Terms: "GPT-5.6 Sol via ChatGPT Codex subscription.",
+		},
+		Preview:            true,
+		SupportedEndpoints: []string{"/responses"},
+		Vendor:             "OpenAI",
+		Version:            "gpt-5.6-sol",
+	},
 	modelGPT5Codex: {
 		Capabilities: map[string]interface{}{
 			"family": "gpt-5-codex",
@@ -502,6 +537,7 @@ var supportedModelIDs = []string{
 	modelGPT53Codex,
 	modelGPT53CodexSpark,
 	modelGPT55,
+	modelGPT5Sol,
 	modelGPT5Codex,
 	modelGPT51,
 	modelGPT51Codex,

--- a/internal/server/models_test.go
+++ b/internal/server/models_test.go
@@ -24,6 +24,7 @@ func TestSupportedModelsIncludesBaseAndSuffixVariants(t *testing.T) {
 		modelGPT53Codex,
 		modelGPT53CodexSpark,
 		modelGPT55,
+		modelGPT5Sol,
 		modelGPT5CodexMini,
 		modelGPT51CodexMini,
 	} {
@@ -58,6 +59,10 @@ func TestSupportedModelsIncludesBaseAndSuffixVariants(t *testing.T) {
 		"gpt-5.5-medium",
 		"gpt-5.5-high",
 		"gpt-5.5-xhigh",
+		"gpt-5.6-sol-low",
+		"gpt-5.6-sol-medium",
+		"gpt-5.6-sol-high",
+		"gpt-5.6-sol-xhigh",
 		"gpt-5-codex-high",
 		"gpt-5-codex-minimal",
 		"gpt-5.1-codex-medium",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -450,14 +450,14 @@ func (s *Server) makeChatGPTRequest(r *http.Request, url string, body []byte, to
 
 	// Set headers for ChatGPT backend
 	proxyReq.Header.Set("authorization", "Bearer "+bareToken)
-	proxyReq.Header.Set("version", "0.125.0")
+	proxyReq.Header.Set("version", "0.144.6")
 	proxyReq.Header.Set("openai-beta", "responses=experimental")
 	proxyReq.Header.Set("session_id", newUUIDv4())
 	proxyReq.Header.Set("accept", "text/event-stream")
 	proxyReq.Header.Set("content-type", "application/json")
 	proxyReq.Header.Set("chatgpt-account-id", accountID)
 	proxyReq.Header.Set("originator", "codex_cli_rs")
-	proxyReq.Header.Set("user-agent", "codex_cli_rs/0.125.0 (Mac OS 26.3.0; arm64) Apple_Terminal/466")
+	proxyReq.Header.Set("user-agent", "codex_cli_rs/0.144.6 (Mac OS 26.3.0; arm64) Apple_Terminal/466")
 	proxyReq.Header.Set("x-codex-beta-features", "multi_agent,apps,prevent_idle_sleep")
 	// The CLI uses turn_id, so let's mock one
 	proxyReq.Header.Set("x-codex-turn-metadata", `{"turn_id":"`+newUUIDv4()+`","sandbox":"none"}`)

--- a/internal/server/transform.go
+++ b/internal/server/transform.go
@@ -304,6 +304,9 @@ func normalizeModel(model string) string {
 	}
 
 	// Prefer explicit new model IDs first to keep mapping predictable.
+	if lower == modelGPT5Sol {
+		return modelGPT5Sol
+	}
 	if lower == modelGPT55 {
 		return modelGPT55
 	}

--- a/internal/server/transform_test.go
+++ b/internal/server/transform_test.go
@@ -159,6 +159,8 @@ func TestNormalizeModel(t *testing.T) {
 		{"gpt-5.4 with effort suffix", "gpt-5.4-high", "gpt-5.4"},
 		{"gpt-5.5 base", "gpt-5.5", "gpt-5.5"},
 		{"gpt-5.5 with suffix", "gpt-5.5-xhigh", "gpt-5.5"},
+		{"gpt-5.6-sol base", "gpt-5.6-sol", "gpt-5.6-sol"},
+		{"gpt-5.6-sol with effort suffix", "gpt-5.6-sol-high", "gpt-5.6-sol"},
 		{"gpt-5.1 with suffix", "gpt-5.1-high", "gpt-5.1"},
 		{"gpt-5.1 codex", "gpt-5.1-codex", "gpt-5.1-codex"},
 		{"gpt-5.1 codex max", "gpt-5.1-codex-max", "gpt-5.1-codex-max"},


### PR DESCRIPTION
## What
Add support for the GPT-5.6 Sol model (ChatGPT Codex subscription) to the proxy, and bump the upstream version header that gates it.

## Why
- The ChatGPT backend serves `gpt-5.6-sol` (verified: returns 200 and streams `model":"gpt-5.6-sol"`).
- `normalizeModel()` only knew models up to gpt-5.5, so `gpt-5.6-sol` fell through to the `gpt-5` catch-all. That was rejected by the backend with `400 The 'gpt-5' model is not supported when using Codex with a ChatGPT account.`
- The backend ALSO rejects `gpt-5.6-sol` when the proxy's hardcoded `version`/user-agent claims an old Codex CLI: `400 The 'gpt-5.6-sol' model requires a newer version of Codex.` The proxy hardcoded `0.125.0`; `0.144.6` (the current CLI) serves it fine.

## Changes
- `models.go`: add `gpt-5.6-sol` constant, allowed efforts `low/medium/high/xhigh` (backend rejects `minimal` — verified), default effort `medium`, `/responses` endpoint, preview metadata.
- `transform.go`: `normalizeModel()` maps `gpt-5.6-sol` (and effort-suffixed variants) to itself instead of collapsing to `gpt-5`.
- `server.go`: bump `version` and user-agent from `0.125.0` to `0.144.6`.
- Tests: normalizeModel + supportedModels cases for gpt-5.6-sol.

## Validation
Verified against a live ChatGPT Codex subscription through the running proxy: `gpt-5.6-sol` responses call returns HTTP 200 and streams the model. `go test ./internal/server/` passes.