### PR TITLE
Fix model list token refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,8 @@ The proxy provides two primary modes of operation via distinct endpoints:
 
 ### Cross-Provider Session Resumption
 
-- Preserve encrypted reasoning items on the first upstream request so native ChatGPT reasoning continuity is not lost.
-- If upstream returns `invalid_encrypted_content`, retry once without encrypted reasoning items while preserving conversation and tool history.
+- Preserve encrypted reasoning items so native ChatGPT reasoning continuity is not lost.
+- Treat provider-specific encrypted reasoning as non-portable and pass upstream compatibility errors through to the client.
 - Preserve response item IDs up to the upstream 64-character limit; remove longer foreign IDs before forwarding.
 
 ### Environment Requirements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+- Repo: dvcrn/codex-oauth-proxy
+
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
@@ -13,33 +15,11 @@ The server uses zerolog for structured JSON logging with zero allocations and hi
 ### Building and Running
 
 ```bash
-# Build the binary (automatically formats code first)
-just build
-
-# Run the server locally
-just run
+# Build the binary
+mise run build
 
 # Run tests
-just test
-
-# Install to GOPATH/bin
-just install
-
-# Build and push Docker image
-just docker-build
-```
-
-### Development Workflow
-
-```bash
-# Format Go code (basic formatting)
-just fmt
-
-# Format Go code with goimports (organizes imports and formats)
-just format
-
-# Clean build artifacts
-just clean
+mise run test
 ```
 
 ### Releasing
@@ -100,6 +80,12 @@ The proxy provides two primary modes of operation via distinct endpoints:
    - Normalizes the requested model and reasoning effort/summary settings
    - Forces streaming mode and derives a prompt cache key
    - Configures Codex-specific headers (Codex CLI user-agent, ChatGPT account ID, beta feature flags)
+
+### Cross-Provider Session Resumption
+
+- Preserve encrypted reasoning items on the first upstream request so native ChatGPT reasoning continuity is not lost.
+- If upstream returns `invalid_encrypted_content`, retry once without encrypted reasoning items while preserving conversation and tool history.
+- Preserve response item IDs up to the upstream 64-character limit; remove longer foreign IDs before forwarding.
 
 ### Environment Requirements
 

--- a/internal/server/mcp_handler_test.go
+++ b/internal/server/mcp_handler_test.go
@@ -24,27 +24,50 @@ func (stubCredentialsFetcher) GetCredentials() (string, string, error) {
 }
 func (stubCredentialsFetcher) RefreshCredentials() error { return nil }
 
+type refreshingCredentialsFetcher struct {
+	refreshes int
+}
+
+func (f *refreshingCredentialsFetcher) GetCredentials() (string, string, error) {
+	return "test-token", "test-account", nil
+}
+
+func (f *refreshingCredentialsFetcher) RefreshCredentials() error {
+	f.refreshes++
+	return nil
+}
+
 // stubModelsHTTPClient serves a canned /backend-api/codex/models payload so the
 // model-listing tests do not depend on the network or a live account.
 type stubModelsHTTPClient struct {
-	body       string
-	statusCode int
-	err        error
-	calls      int
+	body        string
+	bodies      []string
+	statusCode  int
+	statusCodes []int
+	err         error
+	calls       int
 }
 
 func (c *stubModelsHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	callIndex := c.calls
 	c.calls++
 	if c.err != nil {
 		return nil, c.err
 	}
 	status := c.statusCode
+	if callIndex < len(c.statusCodes) {
+		status = c.statusCodes[callIndex]
+	}
 	if status == 0 {
 		status = http.StatusOK
 	}
+	body := c.body
+	if callIndex < len(c.bodies) {
+		body = c.bodies[callIndex]
+	}
 	return &http.Response{
 		StatusCode: status,
-		Body:       io.NopCloser(strings.NewReader(c.body)),
+		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     make(http.Header),
 		Request:    req,
 	}, nil
@@ -251,7 +274,28 @@ func TestMCPAskCodexModelsUpstreamFailure(t *testing.T) {
 
 	_, err := srv.mcpAskCodexModels(t.Context(), askCodexModelsInput{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "upstream returned 401")
+	assert.Contains(t, err.Error(), "upstream authentication failed")
+}
+
+func TestMCPAskCodexModelsRefreshesAndRetriesOnUnauthorized(t *testing.T) {
+	srv := newMCPTestServer(t)
+	creds := &refreshingCredentialsFetcher{}
+	stub := &stubModelsHTTPClient{
+		statusCodes: []int{http.StatusUnauthorized, http.StatusOK},
+		bodies: []string{
+			`{"detail":"Could not parse your authentication token."}`,
+			upstreamModelsFixture,
+		},
+	}
+	srv.credsFetcher = creds
+	srv.httpClient = stub
+
+	out, err := srv.mcpAskCodexModels(t.Context(), askCodexModelsInput{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, creds.refreshes)
+	assert.Equal(t, 2, stub.calls)
+	require.Len(t, out.Models, 2)
 }
 
 func mcpResultText(t *testing.T, result map[string]interface{}) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -402,6 +402,29 @@ func (s *Server) responsesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if statusCode == http.StatusBadRequest && responseAPIErrorCode(responseData) == "invalid_encrypted_content" {
+		removed := removeEncryptedReasoningInput(requestData)
+		if removed > 0 {
+			responseData.Body.Close()
+			modifiedBodyBytes, err = json.Marshal(requestData)
+			if err != nil {
+				s.logger.Error().Err(err).Msg("Error marshalling responses compatibility retry")
+				http.Error(w, "Failed to prepare modified request", http.StatusInternalServerError)
+				return
+			}
+
+			s.logger.Warn().
+				Int("removed_reasoning_items", removed).
+				Msg("Retrying responses request without undecryptable reasoning state")
+			responseData, statusCode, err = s.makeChatGPTRequestWithRetry(r, upstreamURL, modifiedBodyBytes, normalizedModel)
+			if err != nil {
+				s.logger.Error().Err(err).Msg("Error retrying responses request without encrypted reasoning")
+				http.Error(w, "Failed to communicate with upstream API: "+err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+		}
+	}
+
 	if statusCode >= 400 {
 		preview := previewResponseBody(responseData)
 		shape := describeResponsesInputShape(requestData)
@@ -445,6 +468,29 @@ func previewResponseBody(resp *http.Response) string {
 		return preview[:1200] + "…(truncated)"
 	}
 	return preview
+}
+
+func responseAPIErrorCode(resp *http.Response) string {
+	if resp == nil || resp.Body == nil {
+		return ""
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(nil))
+		return ""
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	var payload struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(bodyBytes, &payload); err != nil {
+		return ""
+	}
+	return payload.Error.Code
 }
 
 func describeResponsesInputShape(body map[string]interface{}) []string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -130,6 +131,21 @@ func (s *Server) modelsHandler(w http.ResponseWriter, r *http.Request) {
 	upstream, err := s.fetchUpstreamModels(r.Context())
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Failed to list upstream models")
+		var authErr *upstreamAuthError
+		if errors.As(err, &authErr) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			if encodeErr := json.NewEncoder(w).Encode(map[string]interface{}{
+				"error": map[string]interface{}{
+					"message": "Codex upstream authentication failed. Refresh the OAuth credentials and retry.",
+					"type":    "authentication_error",
+					"code":    "token_expired",
+				},
+			}); encodeErr != nil {
+				s.logger.Error().Err(encodeErr).Msg("Failed to encode authentication error response")
+			}
+			return
+		}
 		http.Error(w, "Failed to list models: "+err.Error(), http.StatusBadGateway)
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -402,29 +402,6 @@ func (s *Server) responsesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if statusCode == http.StatusBadRequest && responseAPIErrorCode(responseData) == "invalid_encrypted_content" {
-		removed := removeEncryptedReasoningInput(requestData)
-		if removed > 0 {
-			responseData.Body.Close()
-			modifiedBodyBytes, err = json.Marshal(requestData)
-			if err != nil {
-				s.logger.Error().Err(err).Msg("Error marshalling responses compatibility retry")
-				http.Error(w, "Failed to prepare modified request", http.StatusInternalServerError)
-				return
-			}
-
-			s.logger.Warn().
-				Int("removed_reasoning_items", removed).
-				Msg("Retrying responses request without undecryptable reasoning state")
-			responseData, statusCode, err = s.makeChatGPTRequestWithRetry(r, upstreamURL, modifiedBodyBytes, normalizedModel)
-			if err != nil {
-				s.logger.Error().Err(err).Msg("Error retrying responses request without encrypted reasoning")
-				http.Error(w, "Failed to communicate with upstream API: "+err.Error(), http.StatusServiceUnavailable)
-				return
-			}
-		}
-	}
-
 	if statusCode >= 400 {
 		preview := previewResponseBody(responseData)
 		shape := describeResponsesInputShape(requestData)
@@ -468,29 +445,6 @@ func previewResponseBody(resp *http.Response) string {
 		return preview[:1200] + "…(truncated)"
 	}
 	return preview
-}
-
-func responseAPIErrorCode(resp *http.Response) string {
-	if resp == nil || resp.Body == nil {
-		return ""
-	}
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(nil))
-		return ""
-	}
-	resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-
-	var payload struct {
-		Error struct {
-			Code string `json:"code"`
-		} `json:"error"`
-	}
-	if err := json.Unmarshal(bodyBytes, &payload); err != nil {
-		return ""
-	}
-	return payload.Error.Code
 }
 
 func describeResponsesInputShape(body map[string]interface{}) []string {

--- a/internal/server/transform_responses.go
+++ b/internal/server/transform_responses.go
@@ -149,30 +149,3 @@ func sanitizeResponsesInput(body map[string]interface{}) {
 	}
 	body["input"] = filtered
 }
-
-func removeEncryptedReasoningInput(body map[string]interface{}) int {
-	input, ok := body["input"].([]interface{})
-	if !ok {
-		return 0
-	}
-
-	removed := 0
-	filtered := input[:0:0]
-	for _, item := range input {
-		itemMap, ok := item.(map[string]interface{})
-		if !ok {
-			filtered = append(filtered, item)
-			continue
-		}
-		itemType, _ := itemMap["type"].(string)
-		_, hasEncryptedContent := itemMap["encrypted_content"]
-		if itemType == "reasoning" && hasEncryptedContent {
-			removed++
-			continue
-		}
-		filtered = append(filtered, item)
-	}
-	body["input"] = filtered
-
-	return removed
-}

--- a/internal/server/transform_responses.go
+++ b/internal/server/transform_responses.go
@@ -126,6 +126,7 @@ func sanitizeResponsesInput(body map[string]interface{}) {
 		if role, _ := msgMap["role"].(string); role == "system" {
 			continue
 		}
+		delete(msgMap, "id")
 		contents, ok := msgMap["content"].([]interface{})
 		if !ok {
 			filtered = append(filtered, msg)

--- a/internal/server/transform_responses.go
+++ b/internal/server/transform_responses.go
@@ -2,6 +2,8 @@ package server
 
 import "strings"
 
+const maxResponsesInputItemIDLength = 64
+
 func transformResponsesRequestBody(body map[string]interface{}, requestedModel string, requestedEffort string) (string, string) {
 	normalizedModel := normalizeModel(requestedModel)
 	body["model"] = normalizedModel
@@ -126,7 +128,9 @@ func sanitizeResponsesInput(body map[string]interface{}) {
 		if role, _ := msgMap["role"].(string); role == "system" {
 			continue
 		}
-		delete(msgMap, "id")
+		if id, ok := msgMap["id"].(string); ok && len(id) > maxResponsesInputItemIDLength {
+			delete(msgMap, "id")
+		}
 		contents, ok := msgMap["content"].([]interface{})
 		if !ok {
 			filtered = append(filtered, msg)
@@ -144,4 +148,31 @@ func sanitizeResponsesInput(body map[string]interface{}) {
 		filtered = append(filtered, msg)
 	}
 	body["input"] = filtered
+}
+
+func removeEncryptedReasoningInput(body map[string]interface{}) int {
+	input, ok := body["input"].([]interface{})
+	if !ok {
+		return 0
+	}
+
+	removed := 0
+	filtered := input[:0:0]
+	for _, item := range input {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		itemType, _ := itemMap["type"].(string)
+		_, hasEncryptedContent := itemMap["encrypted_content"]
+		if itemType == "reasoning" && hasEncryptedContent {
+			removed++
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	body["input"] = filtered
+
+	return removed
 }

--- a/internal/server/transform_responses_test.go
+++ b/internal/server/transform_responses_test.go
@@ -182,3 +182,57 @@ func TestTransformResponsesRequestBody_ModelSpecificReasoningClamp(t *testing.T)
 		t.Fatalf("expected reasoning effort low in body, got %v", body4["reasoning"])
 	}
 }
+
+func TestTransformResponsesRequestBody_StripsForeignInputItemIDs(t *testing.T) {
+	longForeignID := strings.Repeat("grok-session-item-", 5)
+	body := map[string]interface{}{
+		"input": []interface{}{
+			map[string]interface{}{
+				"type": "message",
+				"id":   longForeignID,
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{
+						"type": "input_text",
+						"text": "Continue this session",
+					},
+				},
+			},
+			map[string]interface{}{
+				"type":      "function_call",
+				"id":        longForeignID,
+				"call_id":   "call_keep_this",
+				"name":      "lookup",
+				"arguments": "{}",
+			},
+			map[string]interface{}{
+				"type":    "function_call_output",
+				"id":      longForeignID,
+				"call_id": "call_keep_this",
+				"output":  "done",
+			},
+		},
+	}
+
+	transformResponsesRequestBody(body, modelGPT55, "medium")
+
+	input := body["input"].([]interface{})
+	for idx, rawItem := range input {
+		item, ok := rawItem.(map[string]interface{})
+		if !ok {
+			t.Fatalf("input[%d] should be a map, got %T", idx, rawItem)
+		}
+		if _, exists := item["id"]; exists {
+			t.Fatalf("input[%d] should not preserve foreign id %q", idx, item["id"])
+		}
+	}
+
+	functionCall := input[1].(map[string]interface{})
+	if functionCall["call_id"] != "call_keep_this" {
+		t.Fatalf("expected function call_id to be preserved, got %v", functionCall["call_id"])
+	}
+	functionOutput := input[2].(map[string]interface{})
+	if functionOutput["call_id"] != "call_keep_this" {
+		t.Fatalf("expected function output call_id to be preserved, got %v", functionOutput["call_id"])
+	}
+}

--- a/internal/server/transform_responses_test.go
+++ b/internal/server/transform_responses_test.go
@@ -1,9 +1,31 @@
 package server
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/rs/zerolog"
 )
+
+type responsesRetryHTTPClient struct {
+	responses     []*http.Response
+	requestBodies [][]byte
+}
+
+func (client *responsesRetryHTTPClient) Do(request *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		return nil, err
+	}
+	client.requestBodies = append(client.requestBodies, body)
+
+	response := client.responses[0]
+	client.responses = client.responses[1:]
+	return response, nil
+}
 
 func TestTransformResponsesRequestBody(t *testing.T) {
 	body := map[string]interface{}{
@@ -183,8 +205,9 @@ func TestTransformResponsesRequestBody_ModelSpecificReasoningClamp(t *testing.T)
 	}
 }
 
-func TestTransformResponsesRequestBody_StripsForeignInputItemIDs(t *testing.T) {
+func TestTransformResponsesRequestBody_PreservesPortableResponseState(t *testing.T) {
 	longForeignID := strings.Repeat("grok-session-item-", 5)
+	validChatGPTID := "rs_chatgpt_reasoning"
 	body := map[string]interface{}{
 		"input": []interface{}{
 			map[string]interface{}{
@@ -197,6 +220,11 @@ func TestTransformResponsesRequestBody_StripsForeignInputItemIDs(t *testing.T) {
 						"text": "Continue this session",
 					},
 				},
+			},
+			map[string]interface{}{
+				"type":              "reasoning",
+				"id":                validChatGPTID,
+				"encrypted_content": "gAAAAAB-chatgpt-private-reasoning",
 			},
 			map[string]interface{}{
 				"type":      "function_call",
@@ -217,22 +245,119 @@ func TestTransformResponsesRequestBody_StripsForeignInputItemIDs(t *testing.T) {
 	transformResponsesRequestBody(body, modelGPT55, "medium")
 
 	input := body["input"].([]interface{})
+	if len(input) != 4 {
+		t.Fatalf("expected all response items to be preserved, got %d input items", len(input))
+	}
 	for idx, rawItem := range input {
 		item, ok := rawItem.(map[string]interface{})
 		if !ok {
 			t.Fatalf("input[%d] should be a map, got %T", idx, rawItem)
 		}
-		if _, exists := item["id"]; exists {
+		if id, exists := item["id"]; exists && len(id.(string)) > maxResponsesInputItemIDLength {
 			t.Fatalf("input[%d] should not preserve foreign id %q", idx, item["id"])
 		}
 	}
 
-	functionCall := input[1].(map[string]interface{})
+	reasoning := input[1].(map[string]interface{})
+	if reasoning["id"] != validChatGPTID || reasoning["encrypted_content"] == "" {
+		t.Fatalf("expected ChatGPT reasoning state to be preserved, got %v", reasoning)
+	}
+
+	functionCall := input[2].(map[string]interface{})
 	if functionCall["call_id"] != "call_keep_this" {
 		t.Fatalf("expected function call_id to be preserved, got %v", functionCall["call_id"])
 	}
-	functionOutput := input[2].(map[string]interface{})
+	functionOutput := input[3].(map[string]interface{})
 	if functionOutput["call_id"] != "call_keep_this" {
 		t.Fatalf("expected function output call_id to be preserved, got %v", functionOutput["call_id"])
+	}
+}
+
+func TestRemoveEncryptedReasoningInput(t *testing.T) {
+	body := map[string]interface{}{
+		"input": []interface{}{
+			map[string]interface{}{
+				"type":              "reasoning",
+				"id":                "rs_foreign",
+				"encrypted_content": "ClOk-foreign-private-reasoning",
+			},
+			map[string]interface{}{
+				"type":    "reasoning",
+				"id":      "rs_summary_only",
+				"summary": []interface{}{},
+			},
+			map[string]interface{}{
+				"type":      "function_call",
+				"call_id":   "call_keep_this",
+				"name":      "lookup",
+				"arguments": "{}",
+			},
+		},
+	}
+
+	removed := removeEncryptedReasoningInput(body)
+	if removed != 1 {
+		t.Fatalf("expected one encrypted reasoning item removed, got %d", removed)
+	}
+
+	input := body["input"].([]interface{})
+	if len(input) != 2 {
+		t.Fatalf("expected two portable items to remain, got %d", len(input))
+	}
+	if input[0].(map[string]interface{})["id"] != "rs_summary_only" {
+		t.Fatalf("expected non-encrypted reasoning item to remain, got %v", input[0])
+	}
+	if input[1].(map[string]interface{})["call_id"] != "call_keep_this" {
+		t.Fatalf("expected function call to remain, got %v", input[1])
+	}
+}
+
+func TestResponsesHandler_RetriesUndecryptableReasoning(t *testing.T) {
+	client := &responsesRetryHTTPClient{
+		responses: []*http.Response{
+			{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"error":{"code":"invalid_encrypted_content","message":"could not decrypt"}}`,
+				)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body: io.NopCloser(strings.NewReader(
+					"data: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n",
+				)),
+			},
+		},
+	}
+	server := New(zerolog.Nop(), stubCredentialsFetcher{})
+	server.httpClient = client
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"gpt-5.5",
+		"input":[
+			{"type":"reasoning","id":"rs_foreign","encrypted_content":"ClOk-foreign"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}
+		]
+	}`))
+	recorder := httptest.NewRecorder()
+
+	server.responsesHandler(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected compatibility retry to succeed, got status %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if len(client.requestBodies) != 2 {
+		t.Fatalf("expected two upstream requests, got %d", len(client.requestBodies))
+	}
+	if !strings.Contains(string(client.requestBodies[0]), `"encrypted_content":"ClOk-foreign"`) {
+		t.Fatalf("expected initial request to preserve encrypted reasoning, got %s", client.requestBodies[0])
+	}
+	if strings.Contains(string(client.requestBodies[1]), `"encrypted_content":"ClOk-foreign"`) {
+		t.Fatalf("expected retry to remove encrypted reasoning, got %s", client.requestBodies[1])
+	}
+	if !strings.Contains(string(client.requestBodies[1]), `"text":"continue"`) {
+		t.Fatalf("expected retry to preserve conversation input, got %s", client.requestBodies[1])
 	}
 }

--- a/internal/server/transform_responses_test.go
+++ b/internal/server/transform_responses_test.go
@@ -1,31 +1,9 @@
 package server
 
 import (
-	"io"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
-
-	"github.com/rs/zerolog"
 )
-
-type responsesRetryHTTPClient struct {
-	responses     []*http.Response
-	requestBodies [][]byte
-}
-
-func (client *responsesRetryHTTPClient) Do(request *http.Request) (*http.Response, error) {
-	body, err := io.ReadAll(request.Body)
-	if err != nil {
-		return nil, err
-	}
-	client.requestBodies = append(client.requestBodies, body)
-
-	response := client.responses[0]
-	client.responses = client.responses[1:]
-	return response, nil
-}
 
 func TestTransformResponsesRequestBody(t *testing.T) {
 	body := map[string]interface{}{
@@ -270,94 +248,5 @@ func TestTransformResponsesRequestBody_PreservesPortableResponseState(t *testing
 	functionOutput := input[3].(map[string]interface{})
 	if functionOutput["call_id"] != "call_keep_this" {
 		t.Fatalf("expected function output call_id to be preserved, got %v", functionOutput["call_id"])
-	}
-}
-
-func TestRemoveEncryptedReasoningInput(t *testing.T) {
-	body := map[string]interface{}{
-		"input": []interface{}{
-			map[string]interface{}{
-				"type":              "reasoning",
-				"id":                "rs_foreign",
-				"encrypted_content": "ClOk-foreign-private-reasoning",
-			},
-			map[string]interface{}{
-				"type":    "reasoning",
-				"id":      "rs_summary_only",
-				"summary": []interface{}{},
-			},
-			map[string]interface{}{
-				"type":      "function_call",
-				"call_id":   "call_keep_this",
-				"name":      "lookup",
-				"arguments": "{}",
-			},
-		},
-	}
-
-	removed := removeEncryptedReasoningInput(body)
-	if removed != 1 {
-		t.Fatalf("expected one encrypted reasoning item removed, got %d", removed)
-	}
-
-	input := body["input"].([]interface{})
-	if len(input) != 2 {
-		t.Fatalf("expected two portable items to remain, got %d", len(input))
-	}
-	if input[0].(map[string]interface{})["id"] != "rs_summary_only" {
-		t.Fatalf("expected non-encrypted reasoning item to remain, got %v", input[0])
-	}
-	if input[1].(map[string]interface{})["call_id"] != "call_keep_this" {
-		t.Fatalf("expected function call to remain, got %v", input[1])
-	}
-}
-
-func TestResponsesHandler_RetriesUndecryptableReasoning(t *testing.T) {
-	client := &responsesRetryHTTPClient{
-		responses: []*http.Response{
-			{
-				StatusCode: http.StatusBadRequest,
-				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body: io.NopCloser(strings.NewReader(
-					`{"error":{"code":"invalid_encrypted_content","message":"could not decrypt"}}`,
-				)),
-			},
-			{
-				StatusCode: http.StatusOK,
-				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
-				Body: io.NopCloser(strings.NewReader(
-					"data: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n",
-				)),
-			},
-		},
-	}
-	server := New(zerolog.Nop(), stubCredentialsFetcher{})
-	server.httpClient = client
-
-	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
-		"model":"gpt-5.5",
-		"input":[
-			{"type":"reasoning","id":"rs_foreign","encrypted_content":"ClOk-foreign"},
-			{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}
-		]
-	}`))
-	recorder := httptest.NewRecorder()
-
-	server.responsesHandler(recorder, request)
-
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("expected compatibility retry to succeed, got status %d: %s", recorder.Code, recorder.Body.String())
-	}
-	if len(client.requestBodies) != 2 {
-		t.Fatalf("expected two upstream requests, got %d", len(client.requestBodies))
-	}
-	if !strings.Contains(string(client.requestBodies[0]), `"encrypted_content":"ClOk-foreign"`) {
-		t.Fatalf("expected initial request to preserve encrypted reasoning, got %s", client.requestBodies[0])
-	}
-	if strings.Contains(string(client.requestBodies[1]), `"encrypted_content":"ClOk-foreign"`) {
-		t.Fatalf("expected retry to remove encrypted reasoning, got %s", client.requestBodies[1])
-	}
-	if !strings.Contains(string(client.requestBodies[1]), `"text":"continue"`) {
-		t.Fatalf("expected retry to preserve conversation input, got %s", client.requestBodies[1])
 	}
 }

--- a/internal/server/upstream_models.go
+++ b/internal/server/upstream_models.go
@@ -59,6 +59,26 @@ type upstreamModelsResponse struct {
 	Models []upstreamModel `json:"models"`
 }
 
+type upstreamAuthError struct {
+	statusCode int
+	detail     string
+	err        error
+}
+
+func (e *upstreamAuthError) Error() string {
+	if e.err != nil {
+		return fmt.Sprintf("upstream authentication failed: %v", e.err)
+	}
+	if e.detail != "" {
+		return fmt.Sprintf("upstream authentication failed: %s", e.detail)
+	}
+	return "upstream authentication failed"
+}
+
+func (e *upstreamAuthError) Unwrap() error {
+	return e.err
+}
+
 // fetchUpstreamModels asks the ChatGPT backend which models the current
 // account can use, returning only the user-visible ones. Results are cached
 // for upstreamModelsTTL.
@@ -74,47 +94,9 @@ func (s *Server) fetchUpstreamModels(ctx context.Context) ([]upstreamModel, erro
 		return s.modelsCache, nil
 	}
 
-	token, accountID, err := s.credsFetcher.GetCredentials()
+	parsed, err := s.fetchUpstreamModelsWithRetry(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get credentials: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamModelsURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create models request: %w", err)
-	}
-
-	query := req.URL.Query()
-	query.Set("client_version", codexClientVersion)
-	req.URL.RawQuery = query.Encode()
-
-	bareToken := strings.TrimSpace(token)
-	if len(bareToken) >= 7 && strings.EqualFold(bareToken[:7], "Bearer ") {
-		bareToken = strings.TrimSpace(bareToken[7:])
-	}
-
-	req.Header.Set("authorization", "Bearer "+bareToken)
-	req.Header.Set("version", codexClientVersion)
-	req.Header.Set("chatgpt-account-id", accountID)
-	req.Header.Set("originator", "codex_cli_rs")
-	req.Header.Set("user-agent", "codex_cli_rs/"+codexClientVersion+" (Mac OS 26.3.0; arm64) Apple_Terminal/466")
-	req.Header.Set("accept", "application/json")
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list models: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
-		return nil, fmt.Errorf("failed to list models: upstream returned %d: %s",
-			resp.StatusCode, strings.TrimSpace(string(detail)))
-	}
-
-	var parsed upstreamModelsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-		return nil, fmt.Errorf("failed to parse models response: %w", err)
+		return nil, err
 	}
 
 	visible := make([]upstreamModel, 0, len(parsed.Models))
@@ -138,4 +120,88 @@ func (s *Server) fetchUpstreamModels(ctx context.Context) ([]upstreamModel, erro
 		Msg("Refreshed upstream model list")
 
 	return visible, nil
+}
+
+func (s *Server) fetchUpstreamModelsWithRetry(ctx context.Context) (*upstreamModelsResponse, error) {
+	parsed, statusCode, detail, err := s.fetchUpstreamModelsOnce(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusUnauthorized {
+		if statusCode != http.StatusOK {
+			return nil, fmt.Errorf("failed to list models: upstream returned %d: %s",
+				statusCode, detail)
+		}
+		return parsed, nil
+	}
+
+	s.logger.Warn().
+		Str("response_body", detail).
+		Msg("Received 401 while listing upstream models, attempting token refresh")
+
+	if err := s.credsFetcher.RefreshCredentials(); err != nil {
+		return nil, &upstreamAuthError{statusCode: statusCode, detail: detail, err: fmt.Errorf("token refresh failed: %w", err)}
+	}
+
+	s.logger.Info().Msg("Successfully refreshed credentials, retrying upstream model list")
+
+	parsed, statusCode, detail, err = s.fetchUpstreamModelsOnce(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode == http.StatusUnauthorized {
+		return nil, &upstreamAuthError{statusCode: statusCode, detail: detail}
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list models: upstream returned %d: %s",
+			statusCode, detail)
+	}
+
+	return parsed, nil
+}
+
+func (s *Server) fetchUpstreamModelsOnce(ctx context.Context) (*upstreamModelsResponse, int, string, error) {
+	token, accountID, err := s.credsFetcher.GetCredentials()
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to get credentials: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamModelsURL, nil)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to create models request: %w", err)
+	}
+
+	query := req.URL.Query()
+	query.Set("client_version", codexClientVersion)
+	req.URL.RawQuery = query.Encode()
+
+	bareToken := strings.TrimSpace(token)
+	if len(bareToken) >= 7 && strings.EqualFold(bareToken[:7], "Bearer ") {
+		bareToken = strings.TrimSpace(bareToken[7:])
+	}
+
+	req.Header.Set("authorization", "Bearer "+bareToken)
+	req.Header.Set("version", codexClientVersion)
+	req.Header.Set("chatgpt-account-id", accountID)
+	req.Header.Set("originator", "codex_cli_rs")
+	req.Header.Set("user-agent", "codex_cli_rs/"+codexClientVersion+" (Mac OS 26.3.0; arm64) Apple_Terminal/466")
+	req.Header.Set("accept", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("failed to list models: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, resp.StatusCode, strings.TrimSpace(string(detail)), nil
+	}
+
+	var parsed upstreamModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, resp.StatusCode, "", fmt.Errorf("failed to parse models response: %w", err)
+	}
+
+	return &parsed, resp.StatusCode, "", nil
 }


### PR DESCRIPTION
## Summary

- Add refresh-and-retry handling for upstream 401 responses from the Codex
  model list endpoint.
- Return a structured 401 authentication error from `/v1/models` when refresh
  still fails.
- Cover the model list refresh path with tests.
- Preserve valid response item IDs and native ChatGPT encrypted reasoning.

## Why

The stored OAuth expiry can be stale compared with upstream token validity.
When that happened, `/v1/models` returned an upstream expired-token failure
even though chat, responses, and MCP request paths already retried after
refreshing credentials.

Cross-provider sessions can carry overlong item IDs and provider-specific
encrypted reasoning. The proxy removes only invalid IDs, preserves native
ChatGPT reasoning, and leaves non-portable encrypted reasoning errors explicit.

## Testing

- `mise run test`
- Verified `https://codex.d.pn/health`
- Verified `https://codex.d.pn/v1/models`
- Added coverage proving native encrypted reasoning and valid response item IDs
  are preserved.
- Confirmed journal logs showed upstream `401 token_expired`, credential
  refresh, retry, and successful model list refresh.
